### PR TITLE
Refactor every screen composables for previewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 - [x] Restructure packages and files by introducing new source files.
 - [ ] ~Replace every Spacer composable used in code with various custom AppSpacer.~
 - [x] Separate the ViewModel param from Screen and UI composables to see previews for all screens.
-- [ ] Break composables into smaller for previewing.
-- [x] Break composables into smaller and move them to separate composables packages in each screen.
+- [x] Break composables into smaller for previewing.
+- [x] Separate composables into Screen and UI to separated ViewModel usage and previewing for all screens.
 - [x] Add feature for adding actors to favorites like movies.
 - [x] Add bottom sheet to home screen to support navigation for various screens.
 - [x] Implement paging to upcoming lazy list movies in home tab.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,12 +70,12 @@ dependencies {
 
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.google.android.material:material:1.8.0'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"
-    implementation 'androidx.activity:activity-compose:1.7.0'
+    implementation 'androidx.activity:activity-compose:1.7.1'
 
     // Observe state and livedata
     implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
@@ -107,7 +107,7 @@ dependencies {
     kapt "com.google.dagger:hilt-android-compiler:2.44.2"
 
     // Paging
-    implementation "androidx.paging:paging-compose:1.0.0-alpha18"
+    implementation "androidx.paging:paging-compose:1.0.0-alpha19"
     implementation "androidx.paging:paging-runtime-ktx:3.1.1"
 
     testImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/app/src/androidTest/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUITest.kt
+++ b/app/src/androidTest/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUITest.kt
@@ -3,11 +3,16 @@ package com.developersbreach.composeactors.ui.screens.home
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.paging.PagingData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.developersbreach.composeactors.data.model.Actor
 import com.developersbreach.composeactors.data.model.Movie
 import com.developersbreach.composeactors.ui.screens.search.SearchType
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,22 +24,32 @@ class HomeScreenUITest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
+    private val mockHomeUIState: HomeUIState = HomeUIState(
+        popularActorList = popularActorList,
+        trendingActorList = trendingActorList,
+        isFetchingActors = false,
+        upcomingMoviesList = upcomingMoviesList,
+        nowPlayingMoviesList = flowOf(PagingData.from(nowPlayingMoviesList))
+    )
+
     @Composable
     private fun HomeScreenUIContent(
         selectedActor: (actorId: Int) -> Unit = { },
         selectedMovie: (movieId: Int) -> Unit = { },
-        favoriteMovies: List<Movie> = emptyList(),
         updateSearchType: (searchType: SearchType) -> Unit = {  },
+        navigateToSearchBySearchType: SearchType = SearchType.Actors,
         homeSheetUIState: HomeSheetUIState = HomeSheetUIState(),
-        homeUIState: HomeUIState = HomeUIState()
+        homeUIState: HomeUIState = mockHomeUIState
     ) {
         HomeScreenUI(
             selectedActor = selectedActor,
             selectedMovie = selectedMovie,
-            homeSheetUIState = homeSheetUIState,
-            favoriteMovies = favoriteMovies,
-            updateSearchType = updateSearchType,
-            homeUIState = homeUIState,
+            navigateToFavorite = {},
+            navigateToSearch = {},
+            navigateToSearchBySearchType = navigateToSearchBySearchType,
+            uiState = homeUIState,
+            sheetUiState = homeSheetUIState,
+            updateHomeSearchType = updateSearchType,
         )
     }
 
@@ -58,5 +73,128 @@ class HomeScreenUITest {
             .onNodeWithText(text = "TV Shows")
             .assertIsDisplayed()
             .performClick()
+    }
+
+    @Test
+    fun assertPopularAndTrendingActorsItemsAreVisibleInHomeScreen() {
+        composeTestRule.setContent {
+            HomeScreenUIContent()
+        }
+
+        composeTestRule
+            .onNodeWithText(text = "Monica Bellucci")
+            .assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(text = "Daniel Craig")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun onClickAnyActorItem_InActorsTab_shouldNavigateToActorDetailsScreen() {
+        composeTestRule.setContent {
+            HomeScreenUIContent()
+        }
+
+        // We need to be in actors tab for actors list to appear and interact
+        composeTestRule
+            .onNodeWithText(text = "Actors")
+            .assertIsDisplayed()
+            .performClick()
+
+        // Click actor with name on home screen
+        composeTestRule
+            .onNodeWithText(text = "Monica Bellucci")
+            .assertIsDisplayed()
+            .performClick()
+
+        // If actors name visible in details screen, we have navigated to details screen
+        composeTestRule
+            .onNodeWithText("Monica Bellucci")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun onClickAnyMovieItem_InMoviesTab_shouldNavigateToMovieDetailsScreen() {
+        composeTestRule.setContent {
+            HomeScreenUIContent()
+        }
+
+        // We need to be in movies tab for movies to appear and interact
+        composeTestRule
+            .onNodeWithText(text = "Movies")
+            .assertIsDisplayed()
+            .performClick()
+
+        // Click movie with name on home screen
+        composeTestRule
+            .onNodeWithContentDescription(label = "Oppenheimer")
+            .assertIsDisplayed()
+            .performClick()
+    }
+
+    @Test
+    fun onClickSearchTopAppBar_shouldNavigateToSearchScreen() {
+        composeTestRule.setContent {
+            HomeScreenUIContent(
+                navigateToSearchBySearchType = SearchType.Actors
+            )
+        }
+
+        // We need to be in actors tab for actors list to appear and interact
+        composeTestRule
+            .onNodeWithText(text = "Actors")
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithTag(testTag = "TestTag:HomeTopAppBar")
+            .assertExists()
+            .performClick()
+    }
+
+    companion object {
+        val popularActorList = listOf(
+            Actor(
+                actorId = 28782,
+                actorName = "Monica Bellucci",
+                profileUrl = "z3sLuRKP7hQVrvSTsqdLjGSldwG.jpg"
+            ),
+            Actor(
+                actorId = 287,
+                actorName = "Brad Pitt",
+                profileUrl = "kU3B75TyRiCgE270EyZnHjfivoq.jpg"
+            )
+        )
+        val trendingActorList = listOf(
+            Actor(
+                actorId = 8784,
+                actorName = "Daniel Craig",
+                profileUrl = "rFuETZeyOAfIqBahOObF7Soq5Dh.jpg"
+            ),
+            Actor(
+                actorId = 1892,
+                actorName = "Matt Damon",
+                profileUrl = "7wbHIn7GziFlJLPl8Zu1XVl24EG.jpg"
+            ),
+        )
+
+        val upcomingMoviesList = listOf(
+            Movie(
+                movieId = 363736, movieName = "Oppenheimer", posterPathUrl = "", bannerUrl = ""
+            ),
+            Movie(
+                movieId = 123434, movieName = "Dune", posterPathUrl = "", bannerUrl = ""
+            )
+        )
+
+        val nowPlayingMoviesList = listOf(
+            Movie(
+                movieId = 157336, movieName = "Interstellar", posterPathUrl = "", bannerUrl = ""
+            ),
+            Movie(
+                movieId = 244786, movieName = "Whiplash", posterPathUrl = "", bannerUrl = ""
+            )
+        )
     }
 }

--- a/app/src/androidTest/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUITest.kt
+++ b/app/src/androidTest/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUITest.kt
@@ -9,8 +9,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.paging.PagingData
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.developersbreach.composeactors.data.model.Actor
-import com.developersbreach.composeactors.data.model.Movie
+import com.developersbreach.composeactors.data.datasource.fake.nowPlayingMoviesList
+import com.developersbreach.composeactors.data.datasource.fake.popularActorList
+import com.developersbreach.composeactors.data.datasource.fake.trendingActorList
+import com.developersbreach.composeactors.data.datasource.fake.upcomingMoviesList
 import com.developersbreach.composeactors.ui.screens.search.SearchType
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Rule
@@ -42,8 +44,8 @@ class HomeScreenUITest {
         homeUIState: HomeUIState = mockHomeUIState
     ) {
         HomeScreenUI(
-            selectedActor = selectedActor,
-            selectedMovie = selectedMovie,
+            navigateToSelectedActor = selectedActor,
+            navigateToSelectedMovie = selectedMovie,
             navigateToFavorite = {},
             navigateToSearch = {},
             navigateToSearchBySearchType = navigateToSearchBySearchType,
@@ -151,50 +153,5 @@ class HomeScreenUITest {
             .onNodeWithTag(testTag = "TestTag:HomeTopAppBar")
             .assertExists()
             .performClick()
-    }
-
-    companion object {
-        val popularActorList = listOf(
-            Actor(
-                actorId = 28782,
-                actorName = "Monica Bellucci",
-                profileUrl = "z3sLuRKP7hQVrvSTsqdLjGSldwG.jpg"
-            ),
-            Actor(
-                actorId = 287,
-                actorName = "Brad Pitt",
-                profileUrl = "kU3B75TyRiCgE270EyZnHjfivoq.jpg"
-            )
-        )
-        val trendingActorList = listOf(
-            Actor(
-                actorId = 8784,
-                actorName = "Daniel Craig",
-                profileUrl = "rFuETZeyOAfIqBahOObF7Soq5Dh.jpg"
-            ),
-            Actor(
-                actorId = 1892,
-                actorName = "Matt Damon",
-                profileUrl = "7wbHIn7GziFlJLPl8Zu1XVl24EG.jpg"
-            ),
-        )
-
-        val upcomingMoviesList = listOf(
-            Movie(
-                movieId = 363736, movieName = "Oppenheimer", posterPathUrl = "", bannerUrl = ""
-            ),
-            Movie(
-                movieId = 123434, movieName = "Dune", posterPathUrl = "", bannerUrl = ""
-            )
-        )
-
-        val nowPlayingMoviesList = listOf(
-            Movie(
-                movieId = 157336, movieName = "Interstellar", posterPathUrl = "", bannerUrl = ""
-            ),
-            Movie(
-                movieId = 244786, movieName = "Whiplash", posterPathUrl = "", bannerUrl = ""
-            )
-        )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/data/datasource/fake/ActorData.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/data/datasource/fake/ActorData.kt
@@ -1,0 +1,83 @@
+package com.developersbreach.composeactors.data.datasource.fake
+
+import com.developersbreach.composeactors.data.model.Actor
+import com.developersbreach.composeactors.data.model.ActorDetail
+import com.developersbreach.composeactors.data.model.Cast
+import com.developersbreach.composeactors.data.model.FavoriteActor
+
+private val actorsData = listOf(
+    "John travolta",
+    "Samuel L Jackson",
+    "Uma Thurman",
+    "Bruce Willis",
+    "Ving Rhames",
+    "Harvey Keitel",
+    "Tim Roth",
+    "Amanda Plummer",
+    "Quentin Tarantino",
+    "Christopher Walken",
+    "Eric Stoltz",
+    "Maria de Medeiros",
+    "Rosanna Arquette",
+    "Sophia Lillis",
+)
+
+fun fakeActorsList(): MutableList<Actor> {
+    val actors = mutableListOf<Actor>()
+    actorsData.forEachIndexed { index, name ->
+        actors.add(Actor(index, name, ""))
+    }
+    return actors
+}
+
+fun fakeFavoriteActorsList(): MutableList<FavoriteActor> {
+    val actors = mutableListOf<FavoriteActor>()
+    actorsData.forEachIndexed { index, name ->
+        actors.add(FavoriteActor(index, name, "", "Berlin"))
+    }
+    return actors
+}
+
+fun fakeMovieCastList(): MutableList<Cast> {
+    val cast = mutableListOf<Cast>()
+    actorsData.forEachIndexed { index, name ->
+        cast.add(Cast(index, name, ""))
+    }
+    return cast
+}
+
+val popularActorList = listOf(
+    Actor(
+        actorId = 28782,
+        actorName = "Monica Bellucci",
+        profileUrl = "z3sLuRKP7hQVrvSTsqdLjGSldwG.jpg"
+    ),
+    Actor(
+        actorId = 287,
+        actorName = "Brad Pitt",
+        profileUrl = "kU3B75TyRiCgE270EyZnHjfivoq.jpg"
+    )
+)
+
+val trendingActorList = listOf(
+    Actor(
+        actorId = 8784,
+        actorName = "Daniel Craig",
+        profileUrl = "rFuETZeyOAfIqBahOObF7Soq5Dh.jpg"
+    ),
+    Actor(
+        actorId = 1892,
+        actorName = "Matt Damon",
+        profileUrl = "7wbHIn7GziFlJLPl8Zu1XVl24EG.jpg"
+    ),
+)
+
+val fakeActorDetail = ActorDetail(
+    actorId = 28782,
+    actorName = "Monica Bellucci",
+    profileUrl = "z3sLuRKP7hQVrvSTsqdLjGSldwG.jpg",
+    biography = "This is fake biography for the actor added here to see how the actual preview looks in the screen so don't get any serious about this.",
+    dateOfBirth = "59",
+    placeOfBirth = "Italy",
+    popularity = 43.0
+)

--- a/app/src/main/java/com/developersbreach/composeactors/data/datasource/fake/MovieData.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/data/datasource/fake/MovieData.kt
@@ -1,0 +1,65 @@
+package com.developersbreach.composeactors.data.datasource.fake
+
+import com.developersbreach.composeactors.data.model.Genre
+import com.developersbreach.composeactors.data.model.Movie
+import com.developersbreach.composeactors.data.model.MovieDetail
+
+fun fakeMovieList(): MutableList<Movie> {
+    val movies = mutableListOf<Movie>()
+    listOf(
+        "Pulp Fiction",
+        "Kill Bill: Volume 1",
+        "Taxi Driver",
+        "Goodfellas",
+        "Kill Bill: Volume 2",
+        "Heat",
+        "Scarface",
+        "Scent of a Woman",
+        "The Devil's Advocate",
+        "The Prestige",
+        "Prisoners",
+        "American Psycho",
+        "Logan",
+    ).forEachIndexed { index, name ->
+        movies.add(Movie(index, name, "", ""))
+    }
+
+    return movies
+}
+
+val upcomingMoviesList = listOf(
+    Movie(
+        movieId = 363736, movieName = "Oppenheimer", posterPathUrl = "", bannerUrl = ""
+    ),
+    Movie(
+        movieId = 123434, movieName = "Dune", posterPathUrl = "", bannerUrl = ""
+    )
+)
+
+val nowPlayingMoviesList = listOf(
+    Movie(
+        movieId = 157336, movieName = "Interstellar", posterPathUrl = "", bannerUrl = ""
+    ),
+    Movie(
+        movieId = 244786, movieName = "Whiplash", posterPathUrl = "", bannerUrl = ""
+    )
+)
+
+val fakeMovieDetail = MovieDetail(
+    movieId = 12345,
+    movieTitle = "Pulp Fiction",
+    banner = "banner-url.jpeg",
+    budget = "20 Million",
+    genres = listOf(Genre(1, "Thriller"), Genre(2, "Crime")),
+    originalLanguage = "English",
+    overview = "In the realm of underworld, a series of incidents intertwines the lives of two Los Angeles mobsters, a gangster's wife, a boxer and two small-time criminals.",
+    popularity = 99.0,
+    poster = "poster-url.jpeg",
+    productionCompanies = listOf("Whatever, WhoCares"),
+    releaseDate = "1994",
+    revenue = 21400000,
+    runtime = 154,
+    status = "Released",
+    tagline = "You won't know the facts until you've seen the fiction.",
+    voteAverage = 99.0,
+)

--- a/app/src/main/java/com/developersbreach/composeactors/ui/navigation/AppActions.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/navigation/AppActions.kt
@@ -13,12 +13,12 @@ class AppActions(
 ) {
 
     // Triggered when user tries to navigate to details of an actor from list with Id.
-    val selectedActor: (Int) -> Unit = { actorId: Int ->
+    val navigateToSelectedActor: (Int) -> Unit = { actorId: Int ->
         navController.navigate("${routes.ACTOR_DETAIL_ROUTE}/$actorId")
     }
 
     // Triggered when user tries to navigate to details of an actor from list with Id.
-    val selectedMovie: (Int) -> Unit = { movieId: Int ->
+    val navigateToSelectedMovie: (Int) -> Unit = { movieId: Int ->
         navController.navigate("${routes.MOVIE_DETAILS_ROUTE}/$movieId")
     }
 

--- a/app/src/main/java/com/developersbreach/composeactors/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/navigation/AppNavigation.kt
@@ -2,7 +2,6 @@ package com.developersbreach.composeactors.ui.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -10,7 +9,6 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsScreen
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsViewModel
-import com.developersbreach.composeactors.ui.screens.favorites.FavoriteViewModel
 import com.developersbreach.composeactors.ui.screens.favorites.FavoritesScreen
 import com.developersbreach.composeactors.ui.screens.home.HomeScreen
 import com.developersbreach.composeactors.ui.screens.home.HomeViewModel
@@ -51,13 +49,11 @@ fun AppNavigation(
         composable(
             AppDestinations.HOME_ROUTE
         ) {
-            val homeViewModel = hiltViewModel<HomeViewModel>()
             HomeScreen(
-                selectedActor = actions.selectedActor,
+                navigateToSelectedActor = actions.navigateToSelectedActor,
                 navigateToSearch = actions.navigateToSearch,
                 navigateToFavorite = actions.navigateToFavorite,
-                selectedMovie = actions.selectedMovie,
-                homeViewModel = homeViewModel
+                navigateToSelectedMovie = actions.navigateToSelectedMovie,
             )
         }
 
@@ -72,15 +68,10 @@ fun AppNavigation(
                 navArgument(routes.SEARCH_TYPE) { type = NavType.EnumType(SearchType::class.java) }
             )
         ) {
-            val searchViewModel = hiltViewModel<SearchViewModel>()
-            val selectedIdSearchType = when (searchViewModel.searchType) {
-                SearchType.Actors -> actions.selectedActor
-                SearchType.Movies -> actions.selectedMovie
-            }
             SearchScreen(
-                selectedIdSearchType = selectedIdSearchType,
                 navigateUp = actions.navigateUp,
-                viewModel = searchViewModel
+                navigateToSelectedActor = actions.navigateToSelectedActor,
+                navigateToSelectedMovie = actions.navigateToSelectedMovie,
             )
         }
 
@@ -97,11 +88,9 @@ fun AppNavigation(
                 navArgument(routes.ACTOR_DETAIL_ID_KEY) { type = NavType.IntType }
             )
         ) {
-            val actorDetailsViewModel = hiltViewModel<ActorDetailsViewModel>()
             ActorDetailsScreen(
-                selectedMovie = actions.selectedMovie,
+                navigateToSelectedMovie = actions.navigateToSelectedMovie,
                 navigateUp = actions.navigateUp,
-                viewModel = actorDetailsViewModel
             )
         }
 
@@ -118,23 +107,19 @@ fun AppNavigation(
                 navArgument(routes.MOVIE_DETAILS_ID_KEY) { type = NavType.IntType }
             )
         ) {
-            val viewModel = hiltViewModel<MovieDetailViewModel>()
             MovieDetailScreen(
                 navigateUp = actions.navigateUp,
-                viewModel = viewModel,
-                selectedMovie = actions.selectedMovie
+                navigateToSelectedMovie = actions.navigateToSelectedMovie
             )
         }
 
         composable(
             route = AppDestinations.FAVORITES_ROUTE
         ) {
-            val favoriteViewModel = hiltViewModel<FavoriteViewModel>()
             FavoritesScreen(
                 navigateUp = actions.navigateUp,
-                selectedMovie = actions.selectedMovie,
-                selectedActor = actions.selectedActor,
-                favoriteViewModel = favoriteViewModel
+                navigateToSelectedMovie = actions.navigateToSelectedMovie,
+                navigateToSelectedActor = actions.navigateToSelectedActor,
             )
         }
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/actorDetails/ActorDetailsScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/actorDetails/ActorDetailsScreen.kt
@@ -1,18 +1,10 @@
 package com.developersbreach.composeactors.ui.screens.actorDetails
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.developersbreach.composeactors.ui.screens.home.HomeScreen
-import com.developersbreach.composeactors.ui.screens.modalSheets.manageModalBottomSheet
-import com.developersbreach.composeactors.ui.screens.modalSheets.modalBottomSheetState
-import com.developersbreach.composeactors.ui.screens.movieDetail.composables.FloatingAddToFavoritesButton
 import com.developersbreach.composeactors.ui.screens.search.SearchScreen
 
 
@@ -24,46 +16,24 @@ import com.developersbreach.composeactors.ui.screens.search.SearchScreen
  *
  * This destination can be accessed from [HomeScreen] & [SearchScreen].
  */
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun ActorDetailsScreen(
-    selectedMovie: (Int) -> Unit,
+    viewModel: ActorDetailsViewModel = hiltViewModel(),
+    navigateToSelectedMovie: (Int) -> Unit,
     navigateUp: () -> Unit,
-    viewModel: ActorDetailsViewModel
 ) {
     val detailUIState = viewModel.detailUIState
     val sheetUIState = viewModel.sheetUIState
-    val actorProfileUrl = "${detailUIState.actorData?.profileUrl}"
     val movieId by viewModel.isFavoriteMovie.observeAsState()
 
-    val modalSheetState = modalBottomSheetState()
-    val openActorDetailsBottomSheet = manageModalBottomSheet(
-        modalSheetState = modalSheetState
+    ActorDetailsUI(
+        detailUIState = detailUIState,
+        sheetUIState = sheetUIState,
+        navigateToSelectedMovie = navigateToSelectedMovie,
+        isFavoriteMovie = movieId != 0 && movieId != null,
+        navigateUp = navigateUp,
+        getSelectedMovieDetails = { viewModel.getSelectedMovieDetails(it) },
+        addActorToFavorites = { viewModel.addActorToFavorites() },
+        removeActorFromFavorites = { viewModel.removeActorFromFavorites() }
     )
-
-    val showFab = rememberSaveable { mutableStateOf(true) }
-
-    Box(modifier = Modifier.fillMaxSize()) {
-        ActorDetailsUI(
-            detailUIState = detailUIState,
-            sheetUIState = sheetUIState,
-            actorProfileUrl = actorProfileUrl,
-            modalSheetState = modalSheetState,
-            selectedMovie = selectedMovie,
-            navigateUp = navigateUp,
-            openActorDetailsBottomSheet = openActorDetailsBottomSheet,
-            showFab = showFab,
-            getSelectedMovieDetails = { movieId ->
-                viewModel.getSelectedMovieDetails(movieId)
-            }
-        )
-
-        if (showFab.value) {
-            FloatingAddToFavoritesButton(
-                isFavorite = movieId != 0 && movieId != null,
-                addToFavorites = { viewModel.addActorToFavorites() },
-                removeFromFavorites = { viewModel.removeActorFromFavorites() }
-            )
-        }
-    }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/actorDetails/ActorDetailsUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/actorDetails/ActorDetailsUI.kt
@@ -6,35 +6,41 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.developersbreach.composeactors.data.datasource.fake.fakeActorDetail
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieDetail
 import com.developersbreach.composeactors.ui.components.ImageBackgroundThemeGenerator
 import com.developersbreach.composeactors.ui.components.ShowProgressIndicator
 import com.developersbreach.composeactors.ui.screens.actorDetails.composables.ActorBackgroundWithGradientForeground
 import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentMovieDetails
+import com.developersbreach.composeactors.ui.screens.modalSheets.manageModalBottomSheet
 import com.developersbreach.composeactors.ui.screens.modalSheets.modalBottomSheetState
+import com.developersbreach.composeactors.ui.screens.movieDetail.composables.FloatingAddToFavoritesButton
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
-import kotlinx.coroutines.Job
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun ActorDetailsUI(
     detailUIState: ActorDetailsUIState,
     sheetUIState: ActorDetailsSheetUIState,
-    actorProfileUrl: String,
-    modalSheetState: ModalBottomSheetState,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
+    isFavoriteMovie: Boolean,
     navigateUp: () -> Unit,
-    openActorDetailsBottomSheet: () -> Job,
     getSelectedMovieDetails: (Int) -> Unit,
-    showFab: MutableState<Boolean>
+    addActorToFavorites: () -> Unit,
+    removeActorFromFavorites: () -> Unit
 ) {
+    val showFab = rememberSaveable { mutableStateOf(true) }
+    val actorProfileUrl = "${detailUIState.actorData?.profileUrl}"
+    val modalSheetState = modalBottomSheetState()
+    val openActorDetailsBottomSheet = manageModalBottomSheet(
+        modalSheetState = modalSheetState
+    )
 
     ModalBottomSheetLayout(
         sheetState = modalSheetState,
@@ -44,7 +50,7 @@ internal fun ActorDetailsUI(
         sheetContent = {
             SheetContentMovieDetails(
                 movie = sheetUIState.selectedMovieDetails,
-                selectedMovie = selectedMovie
+                navigateToSelectedMovie = navigateToSelectedMovie
             )
         }
     ) {
@@ -75,30 +81,55 @@ internal fun ActorDetailsUI(
                 ShowProgressIndicator(isLoadingData = detailUIState.isFetchingDetails)
             }
         }
+
+        if (showFab.value) {
+            FloatingAddToFavoritesButton(
+                isFavorite = isFavoriteMovie,
+                addToFavorites = addActorToFavorites,
+                removeFromFavorites = removeActorFromFavorites
+            )
+        }
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
-@Preview
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
 @Composable
-fun ActorDetailsUIPreview() {
-    ComposeActorsTheme {
+private fun ActorDetailsUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
         ActorDetailsUI(
             detailUIState = ActorDetailsUIState(
                 castList = listOf(),
-                actorData = null,
+                actorData = fakeActorDetail,
                 isFetchingDetails = false
             ),
-            sheetUIState = ActorDetailsSheetUIState(
-                selectedMovieDetails = null
-            ),
-            actorProfileUrl = "",
-            modalSheetState = modalBottomSheetState(),
-            selectedMovie = {},
+            sheetUIState = ActorDetailsSheetUIState(fakeMovieDetail),
+            navigateToSelectedMovie = {},
+            isFavoriteMovie = true,
             navigateUp = {},
-            openActorDetailsBottomSheet = { Job() },
             getSelectedMovieDetails = {},
-            showFab = rememberSaveable { mutableStateOf(true) }
+            addActorToFavorites = {},
+            removeActorFromFavorites = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ActorDetailsUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        ActorDetailsUI(
+            detailUIState = ActorDetailsUIState(
+                castList = listOf(),
+                actorData = fakeActorDetail,
+                isFetchingDetails = false
+            ),
+            sheetUIState = ActorDetailsSheetUIState(fakeMovieDetail),
+            navigateToSelectedMovie = {},
+            isFavoriteMovie = true,
+            navigateUp = {},
+            getSelectedMovieDetails = {},
+            addActorToFavorites = {},
+            removeActorFromFavorites = {}
         )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoriteViewModel.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoriteViewModel.kt
@@ -9,33 +9,18 @@ import com.developersbreach.composeactors.data.repository.actor.ActorRepository
 import com.developersbreach.composeactors.data.repository.movie.MovieRepository
 import com.developersbreach.composeactors.domain.useCase.RemoveMovieFromFavoritesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.io.IOException
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @HiltViewModel
 class FavoriteViewModel @Inject constructor(
-    private val movieRepository: MovieRepository,
+    movieRepository: MovieRepository,
     private val actorRepository: ActorRepository,
     private val removeMovieFromFavoritesUseCase: RemoveMovieFromFavoritesUseCase,
 ) : ViewModel() {
+
     val favoriteMovies: LiveData<List<Movie>> = movieRepository.getAllFavoriteMovies()
     val favoriteActors: LiveData<List<FavoriteActor>> = actorRepository.getAllFavoriteActors()
-
-    fun getSelectedMovieDetails(
-        movieId: Int?
-    ) {
-        viewModelScope.launch {
-            try {
-                if (movieId != null) {
-                    movieRepository.getSelectedMovieData(movieId)
-                }
-            } catch (e: IOException) {
-                Timber.e("$e")
-            }
-        }
-    }
 
     fun removeMovieFromFavorites(movie: Movie) {
         viewModelScope.launch {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesScreen.kt
@@ -1,42 +1,21 @@
 package com.developersbreach.composeactors.ui.screens.favorites
 
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Surface
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.developersbreach.composeactors.data.model.FavoriteActor
 import com.developersbreach.composeactors.data.model.Movie
-import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentMovieDetails
 
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun FavoritesScreen(
+    favoriteViewModel: FavoriteViewModel = hiltViewModel(),
     navigateUp: () -> Unit,
-    selectedMovie: (Int) -> Unit,
-    selectedActor: (Int) -> Unit,
-    favoriteViewModel: FavoriteViewModel
+    navigateToSelectedMovie: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
 ) {
     val favoriteMovies by favoriteViewModel.favoriteMovies.observeAsState(emptyList())
     val favoriteActors by favoriteViewModel.favoriteActors.observeAsState(emptyList())
-
-    val modalSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        animationSpec = tween(durationMillis = 500),
-        skipHalfExpanded = true
-    )
 
     val removeFavoriteMovie = { movie: Movie ->
         favoriteViewModel.removeMovieFromFavorites(movie)
@@ -46,41 +25,13 @@ fun FavoritesScreen(
         favoriteViewModel.removeActorFromFavorites(favoriteActor)
     }
 
-    Surface(
-        color = MaterialTheme.colors.background,
-    ) {
-        ModalBottomSheetLayout(
-            sheetState = modalSheetState,
-            scrimColor = Color.Black.copy(alpha = 0.5f),
-            sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-            sheetBackgroundColor = MaterialTheme.colors.background,
-            sheetContent = {
-                SheetContentMovieDetails(
-                    movie = null,
-                    selectedMovie = selectedMovie
-                )
-            }
-        ) {
-            Scaffold(
-                topBar = {
-                    FavoritesTopAppBar(
-                        navigateUp = navigateUp
-                    )
-                }
-            ) { paddingValues ->
-                Box(
-                    modifier = Modifier.padding(paddingValues = paddingValues)
-                ) {
-                    FavoritesScreenUI(
-                        favoriteMovies = favoriteMovies,
-                        selectedMovie = selectedMovie,
-                        selectedActor = selectedActor,
-                        favoriteActors = favoriteActors,
-                        removeFavoriteMovie = removeFavoriteMovie,
-                        removeFavoriteActor = removeFavoriteActor
-                    )
-                }
-            }
-        }
-    }
+    FavoritesScreenUI(
+        navigateUp = navigateUp,
+        favoriteMovies = favoriteMovies,
+        navigateToSelectedMovie = navigateToSelectedMovie,
+        removeFavoriteMovie = removeFavoriteMovie,
+        navigateToSelectedActor = navigateToSelectedActor,
+        favoriteActors = favoriteActors,
+        removeFavoriteActor = removeFavoriteActor
+    )
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesScreenUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesScreenUI.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,10 +30,11 @@ import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FavoritesScreenUI(
+    navigateUp: () -> Unit,
     favoriteMovies: List<Movie>,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     removeFavoriteMovie: (Movie) -> Unit,
-    selectedActor: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
     favoriteActors: List<FavoriteActor>,
     removeFavoriteActor: (FavoriteActor) -> Unit,
 ) {
@@ -41,30 +44,44 @@ fun FavoritesScreenUI(
         TabItem("Movies")
     )
 
-    Column(
-        Modifier.fillMaxSize()
+    Surface(
+        color = MaterialTheme.colors.background,
     ) {
-        TabsContainer(tabs = favoriteTabs, pagerState = favoritesPagerState)
-        AppDivider(thickness = 1.dp, verticalPadding = 0.dp)
-        HorizontalPager(
-            state = favoritesPagerState,
-            pageCount = favoriteTabs.size,
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-        ) {
-            when (it) {
-                0 -> FavoriteActorsTabContent(
-                    getSelectedActorDetails = selectedActor,
-                    favoriteActors = favoriteActors,
-                    removeFavoriteActor = removeFavoriteActor
-                )
-                1 -> FavoriteMoviesTabContent(
-                    getSelectedMovieDetails = selectedMovie,
-                    favoriteMovies = favoriteMovies,
-                    removeFavoriteMovie = removeFavoriteMovie
-                )
-                2 -> FeatureComingSoonTextUI()
+        Scaffold(
+            topBar = {
+                FavoritesTopAppBar(navigateUp = navigateUp)
+            }
+        ) { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues = paddingValues)
+            ) {
+                TabsContainer(tabs = favoriteTabs, pagerState = favoritesPagerState)
+                AppDivider(thickness = 1.dp, verticalPadding = 0.dp)
+                HorizontalPager(
+                    state = favoritesPagerState,
+                    pageCount = favoriteTabs.size,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                ) { index ->
+                    when (index) {
+                        0 -> FavoriteActorsTabContent(
+                            navigateToSelectedActor = navigateToSelectedActor,
+                            favoriteActors = favoriteActors,
+                            removeFavoriteActor = removeFavoriteActor
+                        )
+
+                        1 -> FavoriteMoviesTabContent(
+                            navigateToSelectedMovie = navigateToSelectedMovie,
+                            favoriteMovies = favoriteMovies,
+                            removeFavoriteMovie = removeFavoriteMovie
+                        )
+
+                        2 -> FeatureComingSoonTextUI()
+                    }
+                }
             }
         }
     }
@@ -88,15 +105,32 @@ private fun FeatureComingSoonTextUI() {
 
 @Preview
 @Composable
-private fun FavoriteScreenUIPreview() {
-    ComposeActorsTheme {
+private fun FavoriteScreenUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
         FavoritesScreenUI(
             favoriteMovies = emptyList(),
-            selectedMovie = {},
+            navigateToSelectedMovie = {},
             removeFavoriteMovie = {},
-            selectedActor = {},
+            navigateToSelectedActor = {},
             favoriteActors = emptyList(),
-            removeFavoriteActor = {}
+            removeFavoriteActor = {},
+            navigateUp = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FavoriteScreenUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        FavoritesScreenUI(
+            favoriteMovies = emptyList(),
+            navigateToSelectedMovie = {},
+            removeFavoriteMovie = {},
+            navigateToSelectedActor = {},
+            favoriteActors = emptyList(),
+            removeFavoriteActor = {},
+            navigateUp = {}
         )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesTopAppBar.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/FavoritesTopAppBar.kt
@@ -53,7 +53,7 @@ fun FavoritesTopAppBar(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun FavoritesTopAppBarLightPreview() {
     ComposeActorsTheme(darkTheme = false) {
@@ -61,7 +61,7 @@ private fun FavoritesTopAppBarLightPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
 @Composable
 private fun FavoritesTopAppBarDarkPreview() {
     ComposeActorsTheme(darkTheme = true) {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/tabs/FavoriteActorsTabContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/tabs/FavoriteActorsTabContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeFavoriteActorsList
 import com.developersbreach.composeactors.data.model.FavoriteActor
 import com.developersbreach.composeactors.ui.components.ImageBackgroundThemeGenerator
 import com.developersbreach.composeactors.ui.components.LoadNetworkImage
@@ -38,7 +39,7 @@ import com.developersbreach.composeactors.utils.getPlaceOfBirth
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FavoriteActorsTabContent(
-    getSelectedActorDetails: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
     favoriteActors: List<FavoriteActor>,
     removeFavoriteActor: (FavoriteActor) -> Unit,
 ) {
@@ -58,7 +59,7 @@ fun FavoriteActorsTabContent(
     ) { currentPage ->
         ItemFavoriteActor(
             actorItem = favoriteActors[currentPage],
-            getSelectedActorDetails = getSelectedActorDetails,
+            onClickActor = navigateToSelectedActor,
             removeFavoriteActor = removeFavoriteActor
         )
     }
@@ -67,7 +68,7 @@ fun FavoriteActorsTabContent(
 @Composable
 private fun ItemFavoriteActor(
     actorItem: FavoriteActor,
-    getSelectedActorDetails: (Int) -> Unit,
+    onClickActor: (Int) -> Unit,
     removeFavoriteActor: (FavoriteActor) -> Unit
 ) {
     Box(
@@ -84,7 +85,7 @@ private fun ItemFavoriteActor(
                 .fillMaxWidth()
                 .height(512.dp)
                 .clickable {
-                    getSelectedActorDetails(actorItem.actorId)
+                    onClickActor(actorItem.actorId)
                 }
         )
 
@@ -148,12 +149,48 @@ private fun ItemFavoriteActor(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-private fun FavoriteActorsTabContentPreview() {
-    ComposeActorsTheme {
+private fun FavoriteActorsTabContentPreviewLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
         FavoriteActorsTabContent(
-            getSelectedActorDetails = {},
+            navigateToSelectedActor = {},
+            favoriteActors = fakeFavoriteActorsList(),
+            removeFavoriteActor = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun FavoriteActorsTabContentPreviewDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        FavoriteActorsTabContent(
+            navigateToSelectedActor = {},
+            favoriteActors = fakeFavoriteActorsList(),
+            removeFavoriteActor = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoriteActorsTabContentNoFavoritesPreviewLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        FavoriteActorsTabContent(
+            navigateToSelectedActor = {},
+            favoriteActors = emptyList(),
+            removeFavoriteActor = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun FavoriteActorsTabContentNoFavoritesPreviewDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        FavoriteActorsTabContent(
+            navigateToSelectedActor = {},
             favoriteActors = emptyList(),
             removeFavoriteActor = {}
         )

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/tabs/FavoriteMoviesTabContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/favorites/tabs/FavoriteMoviesTabContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieList
 import com.developersbreach.composeactors.data.model.Movie
 import com.developersbreach.composeactors.ui.components.LoadNetworkImage
 import com.developersbreach.composeactors.ui.screens.favorites.NoFavoritesFoundUI
@@ -39,7 +40,7 @@ import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
  */
 @Composable
 fun FavoriteMoviesTabContent(
-    getSelectedMovieDetails: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     favoriteMovies: List<Movie>,
     removeFavoriteMovie: (Movie) -> Unit,
 ) {
@@ -58,7 +59,7 @@ fun FavoriteMoviesTabContent(
         items(favoriteMovies) { movieItem: Movie ->
             ItemFavoriteMovie(
                 movieItem = movieItem,
-                getSelectedMovieDetails = getSelectedMovieDetails,
+                onClickMovie = navigateToSelectedMovie,
                 removeFavoriteMovie = removeFavoriteMovie
             )
         }
@@ -68,7 +69,7 @@ fun FavoriteMoviesTabContent(
 @Composable
 private fun ItemFavoriteMovie(
     movieItem: Movie,
-    getSelectedMovieDetails: (Int) -> Unit,
+    onClickMovie: (Int) -> Unit,
     removeFavoriteMovie: (Movie) -> Unit
 ) {
     Column(
@@ -84,7 +85,7 @@ private fun ItemFavoriteMovie(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(200.dp)
-                .clickable { getSelectedMovieDetails(movieItem.movieId) }
+                .clickable { onClickMovie(movieItem.movieId) }
         )
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -114,13 +115,49 @@ private fun ItemFavoriteMovie(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-private fun FavoriteMoviesTabContentPreview() {
-    ComposeActorsTheme {
+private fun FavoriteMoviesTabContentLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
         FavoriteMoviesTabContent(
-            getSelectedMovieDetails = {},
-            favoriteMovies = listOf(),
+            navigateToSelectedMovie = {},
+            favoriteMovies = fakeMovieList(),
+            removeFavoriteMovie = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun FavoriteMoviesTabContentDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        FavoriteMoviesTabContent(
+            navigateToSelectedMovie = {},
+            favoriteMovies = fakeMovieList(),
+            removeFavoriteMovie = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun FavoriteMoviesTabContentNoFavoritesLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        FavoriteMoviesTabContent(
+            navigateToSelectedMovie = {},
+            favoriteMovies = emptyList(),
+            removeFavoriteMovie = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun FavoriteMoviesTabContentNoFavoritesDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        FavoriteMoviesTabContent(
+            navigateToSelectedMovie = {},
+            favoriteMovies = emptyList(),
             removeFavoriteMovie = {}
         )
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreen.kt
@@ -1,20 +1,10 @@
 package com.developersbreach.composeactors.ui.screens.home
 
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import com.developersbreach.composeactors.ui.components.ApiKeyMissingShowSnackbar
-import com.developersbreach.composeactors.ui.components.IfOfflineShowSnackbar
-import com.developersbreach.composeactors.ui.screens.home.composables.HomeSnackbar
-import com.developersbreach.composeactors.ui.screens.modalSheets.OptionsModalSheetContent
 import com.developersbreach.composeactors.ui.screens.search.SearchType
 
 /**
@@ -27,7 +17,6 @@ import com.developersbreach.composeactors.ui.screens.search.SearchType
  * Shows [HomeTopAppBar] search box looking ui in [TopAppBar]
  * If user is offline shows snackbar message.
  */
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun HomeScreen(
     selectedActor: (Int) -> Unit,
@@ -36,75 +25,19 @@ fun HomeScreen(
     navigateToFavorite: () -> Unit,
     homeViewModel: HomeViewModel
 ) {
-    // Remember state of scaffold to manage snackbar
-    val scaffoldState = rememberScaffoldState()
-
-    val modalSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        animationSpec = tween(durationMillis = 500),
-        skipHalfExpanded = true
-    )
-
-    val favoriteMovies by homeViewModel.favoriteMovies.observeAsState(emptyList())
     val navigateToSearchBySearchType by homeViewModel.updateHomeSearchType.observeAsState(SearchType.Actors)
 
-    Surface(
-        color = MaterialTheme.colors.background,
-    ) {
-        ModalBottomSheetLayout(
-            sheetState = modalSheetState,
-            scrimColor = Color.Black.copy(alpha = 0.5f),
-            sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-            sheetBackgroundColor = MaterialTheme.colors.background,
-            sheetContent = {
-                OptionsModalSheetContent(
-                    modalSheetSheet = modalSheetState,
-                    navigateToFavorite = navigateToFavorite,
-                    navigateToSearch = { navigateToSearch(SearchType.Movies) },
-                    navigateToProfile = { }
-                )
-            },
-        ) {
-            Scaffold(
-                // attach snackbar host state to the scaffold
-                scaffoldState = scaffoldState,
-                // Custom AppBar contains fake search bar.
-                topBar = {
-                    HomeTopAppBar(
-                        navigateToSearch = navigateToSearch,
-                        searchType = navigateToSearchBySearchType
-                    )
-                },
-                bottomBar = {
-                    HomeBottomBar(
-                        modalSheetSheet = modalSheetState
-                    )
-                },
-                // Host for custom snackbar
-                snackbarHost = { HomeSnackbar(it) }
-            ) { paddingValues ->
-                Box(
-                    modifier = Modifier.padding(paddingValues = paddingValues)
-                ) {
-                    // Main content for this screen
-                    HomeScreenUI(
-                        selectedActor = selectedActor,
-                        homeUIState = homeViewModel.uiState,
-                        homeSheetUIState = homeViewModel.sheetUiState,
-                        favoriteMovies = favoriteMovies,
-                        selectedMovie = selectedMovie,
-                        updateSearchType = { searchType: SearchType ->
-                            homeViewModel.updateHomeSearchType(searchType)
-                        }
-                    )
-
-                    // Perform network check and show snackbar if offline
-                    IfOfflineShowSnackbar(scaffoldState)
-
-                    // If Api key is missing, show a SnackBar.
-                    ApiKeyMissingShowSnackbar(scaffoldState)
-                }
-            }
+    HomeScreenUI(
+        modifier = Modifier,
+        navigateToFavorite = navigateToFavorite,
+        navigateToSearch = navigateToSearch,
+        navigateToSearchBySearchType = navigateToSearchBySearchType,
+        selectedActor = selectedActor,
+        selectedMovie = selectedMovie,
+        uiState = homeViewModel.uiState,
+        sheetUiState = homeViewModel.sheetUiState,
+        updateHomeSearchType = { searchType: SearchType ->
+            homeViewModel.updateHomeSearchType(searchType)
         }
-    }
+    )
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreen.kt
@@ -5,12 +5,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.developersbreach.composeactors.ui.screens.search.SearchType
 
 /**
- * @param selectedActor navigates to user clicked actor from row.
+ * @param navigateToSelectedActor navigates to user clicked actor from row.
  * @param navigateToSearch navigates user to search screen.
- * @param homeViewModel to manage ui state of [HomeScreen]
+ * @param viewModel to manage ui state of [HomeScreen]
  *
  * Default destination.
  * Shows category list of actors in row.
@@ -19,25 +20,25 @@ import com.developersbreach.composeactors.ui.screens.search.SearchType
  */
 @Composable
 fun HomeScreen(
-    selectedActor: (Int) -> Unit,
+    viewModel: HomeViewModel = hiltViewModel(),
+    navigateToSelectedActor: (Int) -> Unit,
     navigateToSearch: (SearchType) -> Unit,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     navigateToFavorite: () -> Unit,
-    homeViewModel: HomeViewModel
 ) {
-    val navigateToSearchBySearchType by homeViewModel.updateHomeSearchType.observeAsState(SearchType.Actors)
+    val navigateToSearchBySearchType by viewModel.updateHomeSearchType.observeAsState(SearchType.Actors)
 
     HomeScreenUI(
         modifier = Modifier,
         navigateToFavorite = navigateToFavorite,
         navigateToSearch = navigateToSearch,
         navigateToSearchBySearchType = navigateToSearchBySearchType,
-        selectedActor = selectedActor,
-        selectedMovie = selectedMovie,
-        uiState = homeViewModel.uiState,
-        sheetUiState = homeViewModel.sheetUiState,
+        navigateToSelectedActor = navigateToSelectedActor,
+        navigateToSelectedMovie = navigateToSelectedMovie,
+        uiState = viewModel.uiState,
+        sheetUiState = viewModel.sheetUiState,
         updateHomeSearchType = { searchType: SearchType ->
-            homeViewModel.updateHomeSearchType(searchType)
+            viewModel.updateHomeSearchType(searchType)
         }
     )
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeScreenUI.kt
@@ -25,19 +25,21 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.developersbreach.composeactors.data.datasource.fake.fakeActorsList
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieDetail
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieList
 import com.developersbreach.composeactors.ui.components.ApiKeyMissingShowSnackbar
 import com.developersbreach.composeactors.ui.components.AppDivider
 import com.developersbreach.composeactors.ui.components.IfOfflineShowSnackbar
 import com.developersbreach.composeactors.ui.components.TabItem
 import com.developersbreach.composeactors.ui.components.TabsContainer
-import com.developersbreach.composeactors.ui.screens.home.composables.HomeSnackbar
 import com.developersbreach.composeactors.ui.screens.home.tabs.ActorsTabContent
 import com.developersbreach.composeactors.ui.screens.home.tabs.MoviesTabContent
 import com.developersbreach.composeactors.ui.screens.home.tabs.TvShowsTabContent
 import com.developersbreach.composeactors.ui.screens.modalSheets.OptionsModalSheetContent
 import com.developersbreach.composeactors.ui.screens.search.SearchType
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
-import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 
 @Composable
 @OptIn(ExperimentalMaterialApi::class)
@@ -46,8 +48,8 @@ fun HomeScreenUI(
     navigateToFavorite: () -> Unit,
     navigateToSearch: (SearchType) -> Unit,
     navigateToSearchBySearchType: SearchType,
-    selectedActor: (Int) -> Unit,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     uiState: HomeUIState,
     sheetUiState: HomeSheetUIState,
     updateHomeSearchType: (SearchType) -> Unit
@@ -64,6 +66,7 @@ fun HomeScreenUI(
         color = MaterialTheme.colors.background,
         modifier = modifier
     ) {
+        // TODO Replace ModalSheet with BottomSheetScaffold
         ModalBottomSheetLayout(
             sheetState = modalSheetState,
             scrimColor = Color.Black.copy(alpha = 0.5f),
@@ -102,10 +105,10 @@ fun HomeScreenUI(
                 ) {
                     // Main content for this screen
                     HomeScreenUI(
-                        selectedActor = selectedActor,
+                        navigateToSelectedActor = navigateToSelectedActor,
                         homeUIState = uiState,
                         homeSheetUIState = sheetUiState,
-                        selectedMovie = selectedMovie,
+                        navigateToSelectedMovie = navigateToSelectedMovie,
                         updateSearchType = updateHomeSearchType
                     )
 
@@ -123,11 +126,11 @@ fun HomeScreenUI(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HomeScreenUI(
-    selectedActor: (Int) -> Unit,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     homeUIState: HomeUIState,
     homeSheetUIState: HomeSheetUIState,
-    updateSearchType: (SearchType) -> Unit
+    updateSearchType: (navigateToSearchByType: SearchType) -> Unit
 ) {
     val popularActorsListState = rememberLazyListState()
     val trendingActorsListState = rememberLazyListState()
@@ -153,7 +156,7 @@ private fun HomeScreenUI(
                     updateSearchType(SearchType.Actors)
                     ActorsTabContent(
                         homeUIState = homeUIState,
-                        getSelectedActorDetails = selectedActor,
+                        navigateToSelectedActor = navigateToSelectedActor,
                         popularActorsListState = popularActorsListState,
                         trendingActorsListState = trendingActorsListState
                     )
@@ -164,7 +167,7 @@ private fun HomeScreenUI(
                     MoviesTabContent(
                         homeUIState = homeUIState,
                         homeSheetUIState = homeSheetUIState,
-                        getSelectedMovieDetails = selectedMovie
+                        navigateToSelectedMovie = navigateToSelectedMovie
                     )
                 }
 
@@ -178,24 +181,42 @@ private fun HomeScreenUI(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
-private fun HomeScreenUIPreview() {
-    ComposeActorsTheme {
+private fun HomeScreenUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
         HomeScreenUI(
-            selectedActor = {},
-            selectedMovie = {},
+            navigateToSelectedActor = {},
+            navigateToSelectedMovie = {},
+            homeSheetUIState = HomeSheetUIState(fakeMovieDetail),
+            updateSearchType = {},
             homeUIState = HomeUIState(
-                popularActorList = listOf(),
-                trendingActorList = listOf(),
+                popularActorList = fakeActorsList(),
+                trendingActorList = fakeActorsList(),
                 isFetchingActors = false,
-                upcomingMoviesList = listOf(),
-                nowPlayingMoviesList = emptyFlow()
+                upcomingMoviesList = fakeMovieList(),
+                nowPlayingMoviesList = flow { fakeMovieList() }
             ),
-            homeSheetUIState = HomeSheetUIState(
-                selectedMovieDetails = null
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun HomeScreenUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        HomeScreenUI(
+            navigateToSelectedActor = {},
+            navigateToSelectedMovie = {},
+            homeSheetUIState = HomeSheetUIState(fakeMovieDetail),
+            updateSearchType = {},
+            homeUIState = HomeUIState(
+                popularActorList = fakeActorsList(),
+                trendingActorList = fakeActorsList(),
+                isFetchingActors = false,
+                upcomingMoviesList = fakeMovieList(),
+                nowPlayingMoviesList = flow { fakeMovieList() }
             ),
-            updateSearchType = {}
         )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeSnackbar.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeSnackbar.kt
@@ -1,4 +1,4 @@
-package com.developersbreach.composeactors.ui.screens.home.composables
+package com.developersbreach.composeactors.ui.screens.home
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Snackbar

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeTopAppBar.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeTopAppBar.kt
@@ -28,6 +28,7 @@ import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
  */
 @Composable
 fun HomeTopAppBar(
+    modifier: Modifier = Modifier,
     navigateToSearch: (SearchType) -> Unit,
     searchType: SearchType
 ) {
@@ -35,7 +36,7 @@ fun HomeTopAppBar(
         content = { HomeTopAppBarContent(navigateToSearch, searchType) },
         backgroundColor = MaterialTheme.colors.background,
         elevation = 0.dp,
-        modifier = Modifier
+        modifier = modifier
             .statusBarsPadding()
             .padding(top = 4.dp, start = 16.dp, end = 16.dp)
     )

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.developersbreach.composeactors.data.model.Movie
 import com.developersbreach.composeactors.data.repository.actor.ActorRepository
 import com.developersbreach.composeactors.data.repository.movie.MovieRepository
 import com.developersbreach.composeactors.domain.GetPagedMovies
@@ -33,8 +32,6 @@ class HomeViewModel @Inject constructor(
 
     var sheetUiState by mutableStateOf(HomeSheetUIState())
         private set
-
-    val favoriteMovies: LiveData<List<Movie>> = movieRepository.getAllFavoriteMovies()
 
     private val _updateHomeSearchType = MutableLiveData<SearchType>()
     val updateHomeSearchType: LiveData<SearchType> = _updateHomeSearchType

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/HomeViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.developersbreach.composeactors.data.repository.actor.ActorRepository
-import com.developersbreach.composeactors.data.repository.movie.MovieRepository
 import com.developersbreach.composeactors.domain.GetPagedMovies
 import com.developersbreach.composeactors.ui.screens.search.SearchType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,7 +21,6 @@ import timber.log.Timber
  */
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-    private val movieRepository: MovieRepository,
     private val actorRepository: ActorRepository,
     private val getPagedMovies: GetPagedMovies
 ) : ViewModel() {
@@ -55,26 +53,6 @@ class HomeViewModel @Inject constructor(
             upcomingMoviesList = actorRepository.getUpcomingMoviesData(),
             nowPlayingMoviesList = getPagedMovies(viewModelScope)
         )
-    }
-
-    /**
-     * @param movieId for querying selected movie details.
-     * This function will be triggered only when user clicks any movie items.
-     * Updates the data values to show in modal sheet.
-     */
-    fun getSelectedMovieDetails(
-        movieId: Int?
-    ) {
-        viewModelScope.launch {
-            try {
-                if (movieId != null) {
-                    val movieData = movieRepository.getSelectedMovieData(movieId)
-                    sheetUiState = HomeSheetUIState(selectedMovieDetails = movieData)
-                }
-            } catch (e: IOException) {
-                Timber.e("$e")
-            }
-        }
     }
 
     fun updateHomeSearchType(searchType: SearchType) {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/ActorsTabContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/ActorsTabContent.kt
@@ -2,12 +2,19 @@ package com.developersbreach.composeactors.ui.screens.home.tabs
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
@@ -19,7 +26,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.developersbreach.composeactors.R
 import com.developersbreach.composeactors.data.model.Actor
@@ -29,14 +35,12 @@ import com.developersbreach.composeactors.ui.components.LoadNetworkImage
 import com.developersbreach.composeactors.ui.components.ShowProgressIndicator
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsScreen
 import com.developersbreach.composeactors.ui.screens.home.HomeUIState
-import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
-import kotlinx.coroutines.flow.emptyFlow
 
 
 @Composable
 fun ActorsTabContent(
     homeUIState: HomeUIState,
-    getSelectedActorDetails: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
     popularActorsListState: LazyListState,
     trendingActorsListState: LazyListState
 ) {
@@ -54,7 +58,7 @@ fun ActorsTabContent(
             // List row of all popular actors.
             ItemActorList(
                 actorsList = homeUIState.popularActorList,
-                selectedActor = getSelectedActorDetails,
+                navigateToSelectedActor = navigateToSelectedActor,
                 actorsListState = popularActorsListState
             )
             AppDivider(verticalPadding = 32.dp)
@@ -64,7 +68,7 @@ fun ActorsTabContent(
             // List row of all trending actors.
             ItemActorList(
                 actorsList = homeUIState.trendingActorList,
-                selectedActor = getSelectedActorDetails,
+                navigateToSelectedActor = navigateToSelectedActor,
                 actorsListState = trendingActorsListState
             )
         }
@@ -77,7 +81,7 @@ fun ActorsTabContent(
 @Composable
 private fun ItemActorList(
     actorsList: List<Actor>,
-    selectedActor: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
     actorsListState: LazyListState
 ) {
     LazyRow(
@@ -91,25 +95,25 @@ private fun ItemActorList(
         ) { actor ->
             ItemActor(
                 actor = actor,
-                selectedActor = selectedActor
+                onClickActor = navigateToSelectedActor
             )
         }
     }
 }
 
 /**
- * @param selectedActor navigate to actor [ActorDetailsScreen] from user selected actor.
+ * @param onClickActor navigate to actor [ActorDetailsScreen] from user selected actor.
  */
 @Composable
 private fun ItemActor(
     actor: Actor,
-    selectedActor: (Int) -> Unit
+    onClickActor: (Int) -> Unit
 ) {
     Card(
         modifier = Modifier
             .width(150.dp)
             .clip(shape = MaterialTheme.shapes.large)
-            .clickable(onClick = { selectedActor(actor.actorId) })
+            .clickable(onClick = { onClickActor(actor.actorId) })
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
@@ -144,24 +148,5 @@ private fun ItemActor(
 
             Spacer(modifier = Modifier.padding(vertical = 12.dp))
         }
-    }
-}
-
-@Preview
-@Composable
-private fun ActorsTabContentPreview() {
-    ComposeActorsTheme {
-        ActorsTabContent(
-            homeUIState = HomeUIState(
-                popularActorList = listOf(),
-                trendingActorList = listOf(),
-                isFetchingActors = false,
-                upcomingMoviesList = listOf(),
-                nowPlayingMoviesList = emptyFlow()
-            ),
-            getSelectedActorDetails = {},
-            popularActorsListState = rememberLazyListState(),
-            trendingActorsListState = rememberLazyListState()
-        )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/MoviesTabContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/MoviesTabContent.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.emptyFlow
 @Composable
 fun MoviesTabContent(
     homeUIState: HomeUIState,
-    getSelectedMovieDetails: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     homeSheetUIState: HomeSheetUIState,
 ) {
     val nowPlayingMovies = homeUIState.nowPlayingMoviesList.collectAsLazyPagingItems()
@@ -62,7 +62,7 @@ fun MoviesTabContent(
             content = {
                 UpcomingMovies(
                     homeUIState = homeUIState,
-                    getSelectedMovieDetails = getSelectedMovieDetails,
+                    navigateToSelectedMovie = navigateToSelectedMovie,
                     modifier = Modifier
                         .height(140.dp)
                         .fillMaxWidth()
@@ -83,7 +83,7 @@ fun MoviesTabContent(
 
         nowPlayingMovies(
             listItems = nowPlayingMovies,
-            getSelectedMovieDetails = getSelectedMovieDetails,
+            navigateToSelectedMovie = navigateToSelectedMovie,
         )
     }
 }
@@ -91,7 +91,7 @@ fun MoviesTabContent(
 @Composable
 private fun UpcomingMovies(
     homeUIState: HomeUIState,
-    getSelectedMovieDetails: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     modifier: Modifier
 ) {
     LazyRow(
@@ -111,7 +111,7 @@ private fun UpcomingMovies(
                 modifier = modifier
                     .width(260.dp)
                     .clickable {
-                        getSelectedMovieDetails(movieItem.movieId)
+                        navigateToSelectedMovie(movieItem.movieId)
                     }
             )
         }
@@ -120,7 +120,7 @@ private fun UpcomingMovies(
 
 private fun LazyGridScope.nowPlayingMovies(
     listItems: LazyPagingItems<Movie>,
-    getSelectedMovieDetails: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
 ) {
     itemsPaging(listItems) { movie ->
         LoadNetworkImage(
@@ -131,7 +131,7 @@ private fun LazyGridScope.nowPlayingMovies(
                 .size(120.dp, 180.dp)
                 .clickable {
                     if (movie != null) {
-                        getSelectedMovieDetails(movie.movieId)
+                        navigateToSelectedMovie(movie.movieId)
                     }
                 }
         )
@@ -150,7 +150,7 @@ private fun MoviesTabContentPreview() {
                 upcomingMoviesList = listOf(),
                 nowPlayingMoviesList = emptyFlow()
             ),
-            getSelectedMovieDetails = {},
+            navigateToSelectedMovie = {},
             homeSheetUIState = HomeSheetUIState()
         )
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/MoviesTabContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/home/tabs/MoviesTabContent.kt
@@ -105,7 +105,7 @@ private fun UpcomingMovies(
         ) { movieItem ->
             LoadNetworkImage(
                 imageUrl = movieItem.posterPathUrl,
-                contentDescription = "",
+                contentDescription = movieItem.movieName,
                 shape = MaterialTheme.shapes.large,
                 showAnimProgress = false,
                 modifier = modifier

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/OptionsModalSheetContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/OptionsModalSheetContent.kt
@@ -66,7 +66,7 @@ fun OptionsModalSheetContent(
                 modifier = Modifier.size(28.dp),
                 onClick = {
                     coroutineScope.launch {
-                        modalSheetSheet.show()
+                        modalSheetSheet.hide()
                     }
                 }
             ) {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/SheetContentActorDetails.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/SheetContentActorDetails.kt
@@ -14,13 +14,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeActorDetail
 import com.developersbreach.composeactors.data.model.ActorDetail
 import com.developersbreach.composeactors.ui.components.LoadNetworkImage
 import com.developersbreach.composeactors.ui.components.SheetHorizontalSeparator
 import com.developersbreach.composeactors.ui.screens.actorDetails.composables.ActorInfoHeader
+import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 
 /**
  * Complete modal sheet content for showing actor details instead of navigating to
@@ -111,4 +114,24 @@ private fun ActorBiographyText(
             fontSize = 16.sp
         )
     )
+}
+
+@Preview
+@Composable
+private fun SheetContentActorDetailsLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        SheetContentActorDetails(
+            actor = fakeActorDetail
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SheetContentActorDetailsDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        SheetContentActorDetails(
+            actor = fakeActorDetail
+        )
+    }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/SheetContentMovieDetails.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/modalSheets/SheetContentMovieDetails.kt
@@ -22,19 +22,22 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieDetail
 import com.developersbreach.composeactors.data.model.MovieDetail
 import com.developersbreach.composeactors.ui.components.CircularSeparator
 import com.developersbreach.composeactors.ui.components.LoadNetworkImage
 import com.developersbreach.composeactors.ui.screens.movieDetail.composables.MovieGenre
+import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 import com.developersbreach.composeactors.utils.getMovieRuntimeFormatted
 
 /**
  * Content inside modal sheet.
  *
- * @param selectedMovie navigates to selected movie details after clicking the icon button
+ * @param navigateToSelectedMovie navigates to selected movie details after clicking the icon button
  * in modal bottom sheet in cast detail screen.
  *
  * This modal sheet shows few details of selected movie from specific cast instead of directly
@@ -43,7 +46,7 @@ import com.developersbreach.composeactors.utils.getMovieRuntimeFormatted
 @Composable
 fun SheetContentMovieDetails(
     movie: MovieDetail?,
-    selectedMovie: (Int) -> Unit
+    navigateToSelectedMovie: (Int) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -51,7 +54,7 @@ fun SheetContentMovieDetails(
             .navigationBarsPadding()
     ) {
         Spacer(modifier = Modifier.height(4.dp))
-        HeaderModalSheet(movie, selectedMovie)
+        HeaderModalSheet(movie, navigateToSelectedMovie)
         Spacer(modifier = Modifier.height(4.dp))
         SeparatorSheetTitleHeader()
         Spacer(modifier = Modifier.height(16.dp))
@@ -76,7 +79,7 @@ fun SheetContentMovieDetails(
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)
         ) {
-            MoviePosterImage(movie, selectedMovie)
+            MoviePosterImage(movie, navigateToSelectedMovie)
             MovieOverviewText(movie?.overview.toString())
         }
 
@@ -87,7 +90,7 @@ fun SheetContentMovieDetails(
 @Composable
 private fun HeaderModalSheet(
     movie: MovieDetail?,
-    selectedMovie: (Int) -> Unit
+    onClickMovie: (Int) -> Unit
 ) {
     Row(
         Modifier
@@ -109,7 +112,7 @@ private fun HeaderModalSheet(
         IconButton(
             onClick = {
                 if (movie != null) {
-                    selectedMovie(movie.movieId)
+                    onClickMovie(movie.movieId)
                 }
             },
             modifier = Modifier
@@ -195,4 +198,26 @@ private fun MovieOverviewText(
             fontSize = 16.sp
         )
     )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SheetContentMovieDetailsLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        SheetContentMovieDetails(
+            movie = fakeMovieDetail,
+            navigateToSelectedMovie = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun SheetContentMovieDetailsDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        SheetContentMovieDetails(
+            movie = fakeMovieDetail,
+            navigateToSelectedMovie = {}
+        )
+    }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailTopAppBar.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailTopAppBar.kt
@@ -27,19 +27,20 @@ import com.developersbreach.composeactors.R
  */
 @Composable
 fun MovieDetailTopAppBar(
+    modifier: Modifier = Modifier,
     navigateUp: () -> Unit,
     title: String?,
     showTopBarBackground: State<Boolean>
 ) {
-    val modifier = if (showTopBarBackground.value) {
-        Modifier.background(color = MaterialTheme.colors.background)
+    val conditionalModifier = if (showTopBarBackground.value) {
+        modifier.background(color = MaterialTheme.colors.background)
     } else {
-        Modifier
+        modifier
     }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier
+        modifier = conditionalModifier
             .fillMaxWidth()
             .statusBarsPadding()
     ) {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailViewModel.kt
@@ -89,7 +89,7 @@ class MovieDetailViewModel @Inject constructor(
                     )
                 )
             } else {
-                Timber.e("Id of $movie was null while delete operation.")
+                Timber.e("Id of ${uiState.movieData?.movieId} was null while delete operation.")
             }
         }
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsContent.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.developersbreach.composeactors.data.model.BottomSheetType
 import com.developersbreach.composeactors.ui.components.CategoryTitle
@@ -17,6 +18,7 @@ import kotlinx.coroutines.Job
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun MovieDetailsContent(
+    modifier: Modifier = Modifier,
     uiState: MovieDetailsUIState,
     navigateUp: () -> Unit,
     showFab: MutableState<Boolean>,
@@ -36,11 +38,12 @@ fun MovieDetailsContent(
 
     LazyColumn(
         state = listState,
-        modifier = Modifier.navigationBarsPadding()
+        modifier = modifier.navigationBarsPadding()
     ) {
 
         stickyHeader {
             MovieDetailTopAppBar(
+                modifier = modifier.testTag("TestTag:MovieDetailTopAppBar"),
                 navigateUp = navigateUp,
                 title = movieData?.movieTitle,
                 showTopBarBackground = showTopBarBackground

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsScreen.kt
@@ -1,9 +1,6 @@
 package com.developersbreach.composeactors.ui.screens.movieDetail
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.developersbreach.composeactors.data.model.BottomSheetType
 import com.developersbreach.composeactors.ui.animations.LayerRevealImage
@@ -29,7 +27,6 @@ import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentMov
 import com.developersbreach.composeactors.ui.screens.modalSheets.manageModalBottomSheet
 import com.developersbreach.composeactors.ui.screens.modalSheets.modalBottomSheetState
 import com.developersbreach.composeactors.ui.screens.movieDetail.composables.FloatingAddToFavoritesButton
-import kotlinx.coroutines.Job
 
 
 /**
@@ -81,13 +78,14 @@ fun MovieDetailScreen(
         },
     ) {
         Box(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize().testTag("TestTag:MovieDetailScreen")
         ) {
             // Background poster with layer reveal effect
             LayerRevealImage(uiState.movieData?.poster, isLayerRevealAnimationEnded)
             // Fade enter animation detail screen once layer reveal completes
             if (isLayerRevealAnimationEnded.value) {
-                AnimateMovieDetailScreenContent(
+                MovieDetailsUI(
+                    modifier = Modifier,
                     uiState = uiState,
                     navigateUp = navigateUp,
                     showFab = showFab,
@@ -144,34 +142,4 @@ private fun setBottomSheetCallBack(
         }
     }
     selectedBottomSheet.value = bottomSheetType
-}
-
-@Composable
-private fun AnimateMovieDetailScreenContent(
-    uiState: MovieDetailsUIState,
-    navigateUp: () -> Unit,
-    showFab: MutableState<Boolean>,
-    openMovieDetailsBottomSheet: () -> Job,
-    selectBottomSheetCallback: (BottomSheetType) -> Unit
-) {
-    val state = remember {
-        MutableTransitionState(false).apply {
-            // Start the animation immediately.
-            targetState = true
-        }
-    }
-
-    AnimatedVisibility(
-        visibleState = state,
-        enter = fadeIn()
-    ) {
-        // Main details content
-        MovieDetailsUI(
-            uiState = uiState,
-            navigateUp = navigateUp,
-            showFab = showFab,
-            openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
-            selectBottomSheetCallback = selectBottomSheetCallback
-        )
-    }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsScreen.kt
@@ -1,132 +1,51 @@
 package com.developersbreach.composeactors.ui.screens.movieDetail
 
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.developersbreach.composeactors.data.model.BottomSheetType
-import com.developersbreach.composeactors.ui.animations.LayerRevealImage
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsScreen
 import com.developersbreach.composeactors.ui.screens.home.HomeScreen
-import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentActorDetails
-import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentMovieDetails
-import com.developersbreach.composeactors.ui.screens.modalSheets.manageModalBottomSheet
-import com.developersbreach.composeactors.ui.screens.modalSheets.modalBottomSheetState
-import com.developersbreach.composeactors.ui.screens.movieDetail.composables.FloatingAddToFavoritesButton
 
 
 /**
  * Screen shows details for the selected movie.
  * This destination can be accessed from [HomeScreen] & [ActorDetailsScreen].
  */
-@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MovieDetailScreen(
-    selectedMovie: (Int) -> Unit,
-    viewModel: MovieDetailViewModel,
+    viewModel: MovieDetailViewModel = hiltViewModel(),
+    navigateToSelectedMovie: (Int) -> Unit,
     navigateUp: () -> Unit
 ) {
     val uiState = viewModel.uiState
-    val sheetUiState = viewModel.sheetUiState
+    val actorsSheetUIState = viewModel.sheetUiState
     val movieSheetUIState = viewModel.movieSheetUiState
-    // This helps us reveal screen content with fadeIn anim once reveal effect is completed.
-    val isLayerRevealAnimationEnded = rememberSaveable { mutableStateOf(false) }
-    // Change button state with respect to scroll changes.
-    val showFab = rememberSaveable { mutableStateOf(true) }
+
     val movieId by viewModel.isFavoriteMovie.observeAsState()
 
-    val modalSheetState = modalBottomSheetState(
-        animationSpec = tween(durationMillis = 300, delayMillis = 50)
-    )
-
-    val selectedBottomSheet =
-        remember { mutableStateOf<BottomSheetType?>(BottomSheetType.MovieDetailBottomSheet) }
+    val selectedBottomSheet = remember {
+        mutableStateOf<BottomSheetType?>(BottomSheetType.MovieDetailBottomSheet)
+    }
 
     val selectBottomSheetCallback = setBottomSheetCallBack(viewModel, selectedBottomSheet)
 
-    val openMovieDetailsBottomSheet = manageModalBottomSheet(
-        modalSheetState = modalSheetState
+    MovieDetailsUI(
+        uiState = uiState,
+        actorsSheetUIState = actorsSheetUIState,
+        movieSheetUIState = movieSheetUIState,
+        navigateUp = navigateUp,
+        selectedBottomSheet = selectedBottomSheet,
+        selectBottomSheetCallback = selectBottomSheetCallback,
+        isFavoriteMovie = movieId != 0 && movieId != null,
+        addMovieToFavorites = { viewModel.addMovieToFavorites() },
+        removeMovieFromFavorites = { viewModel.removeMovieFromFavorites() },
+        navigateToSelectedMovie = navigateToSelectedMovie
     )
-
-    // Sheet content contains details for the selected movie from list.
-    ModalBottomSheetLayout(
-        sheetState = modalSheetState,
-        scrimColor = Color.Black.copy(alpha = 0.5f),
-        sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
-        sheetBackgroundColor = MaterialTheme.colors.background,
-        sheetContent = {
-            GetBottomSheetContent(
-                selectedBottomSheet.value,
-                sheetUiState,
-                movieSheetUIState,
-                selectedMovie
-            )
-        },
-    ) {
-        Box(
-            modifier = Modifier.fillMaxSize().testTag("TestTag:MovieDetailScreen")
-        ) {
-            // Background poster with layer reveal effect
-            LayerRevealImage(uiState.movieData?.poster, isLayerRevealAnimationEnded)
-            // Fade enter animation detail screen once layer reveal completes
-            if (isLayerRevealAnimationEnded.value) {
-                MovieDetailsUI(
-                    modifier = Modifier,
-                    uiState = uiState,
-                    navigateUp = navigateUp,
-                    showFab = showFab,
-                    openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
-                    selectBottomSheetCallback = selectBottomSheetCallback
-                )
-            }
-            // Progress bar - Hidden temporarily, although it works fine cannot have it in current
-            // screen placement since it is on top of reveal animation.
-            // ShowProgressIndicator(isLoadingData = uiState.isFetchingDetails)
-            if (showFab.value) {
-                FloatingAddToFavoritesButton(
-                    isFavorite = movieId != 0 && movieId != null,
-                    addToFavorites = { viewModel.addMovieToFavorites() },
-                    removeFromFavorites = { viewModel.removeMovieFromFavorites() }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun GetBottomSheetContent(
-    bottomSheetType: BottomSheetType?,
-    sheetUiState: ActorsSheetUIState,
-    movieSheetUIState: MovieSheetUIState,
-    selectedMovie: (Int) -> Unit
-) {
-    bottomSheetType?.let { type ->
-        when (type) {
-            BottomSheetType.MovieDetailBottomSheet -> {
-                SheetContentMovieDetails(
-                    movieSheetUIState.selectedMovieDetails,
-                    selectedMovie
-                )
-            }
-            BottomSheetType.ActorDetailBottomSheet -> {
-                SheetContentActorDetails(actor = sheetUiState.selectedActorDetails)
-            }
-        }
-    }
 }
 
 private fun setBottomSheetCallBack(

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsUI.kt
@@ -2,27 +2,52 @@ package com.developersbreach.composeactors.ui.screens.movieDetail
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieCastList
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieDetail
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieList
 import com.developersbreach.composeactors.data.model.BottomSheetType
+import com.developersbreach.composeactors.ui.animations.LayerRevealImage
+import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentActorDetails
+import com.developersbreach.composeactors.ui.screens.modalSheets.SheetContentMovieDetails
+import com.developersbreach.composeactors.ui.screens.modalSheets.manageModalBottomSheet
+import com.developersbreach.composeactors.ui.screens.modalSheets.modalBottomSheetState
+import com.developersbreach.composeactors.ui.screens.movieDetail.composables.FloatingAddToFavoritesButton
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 import kotlinx.coroutines.Job
 
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun MovieDetailsUI(
     modifier: Modifier = Modifier,
     uiState: MovieDetailsUIState,
+    actorsSheetUIState: ActorsSheetUIState,
+    movieSheetUIState: MovieSheetUIState,
     navigateUp: () -> Unit,
-    showFab: MutableState<Boolean>,
-    openMovieDetailsBottomSheet: () -> Job,
-    selectBottomSheetCallback: (BottomSheetType) -> Unit
+    selectedBottomSheet: MutableState<BottomSheetType?>,
+    selectBottomSheetCallback: (BottomSheetType) -> Unit,
+    isFavoriteMovie: Boolean,
+    addMovieToFavorites: () -> Unit,
+    removeMovieFromFavorites: () -> Unit,
+    navigateToSelectedMovie: (movieId: Int) -> Unit,
 ) {
     val state = remember {
         MutableTransitionState(false).apply {
@@ -31,38 +56,132 @@ fun MovieDetailsUI(
         }
     }
 
-    AnimatedVisibility(
-        visibleState = state,
-        enter = fadeIn()
+    val modalSheetState = modalBottomSheetState(
+        animationSpec = tween(durationMillis = 300, delayMillis = 50)
+    )
+
+    val openMovieDetailsBottomSheet = manageModalBottomSheet(
+        modalSheetState = modalSheetState
+    )
+
+    // This helps us reveal screen content with fadeIn anim once reveal effect is completed.
+    val isLayerRevealAnimationEnded = rememberSaveable { mutableStateOf(false) }
+    // Change button state with respect to scroll changes.
+    val showFab = rememberSaveable { mutableStateOf(true) }
+
+    // Sheet content contains details for the selected movie from list.
+    ModalBottomSheetLayout(
+        sheetState = modalSheetState,
+        scrimColor = Color.Black.copy(alpha = 0.5f),
+        sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        sheetBackgroundColor = MaterialTheme.colors.background,
+        sheetContent = {
+            GetBottomSheetContent(
+                selectedBottomSheet.value,
+                actorsSheetUIState,
+                movieSheetUIState,
+                navigateToSelectedMovie
+            )
+        },
     ) {
-        // Main details content
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag("TestTag:MovieDetailScreen")
+        ) {
+            // Background poster with layer reveal effect
+            LayerRevealImage(uiState.movieData?.poster, isLayerRevealAnimationEnded)
+            // Fade enter animation detail screen once layer reveal completes
+            if (isLayerRevealAnimationEnded.value) {
+                AnimatedVisibility(
+                    visibleState = state,
+                    enter = fadeIn()
+                ) {
+                    // Main details content
+                    MovieDetailsContent(
+                        modifier = modifier,
+                        uiState = uiState,
+                        navigateUp = navigateUp,
+                        showFab = showFab,
+                        openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
+                        selectBottomSheetCallback = selectBottomSheetCallback
+                    )
+                }
+            }
+            // Progress bar - Hidden temporarily, although it works fine cannot have it in current
+            // screen placement since it is on top of reveal animation.
+            // ShowProgressIndicator(isLoadingData = uiState.isFetchingDetails)
+            if (showFab.value) {
+                FloatingAddToFavoritesButton(
+                    isFavorite = isFavoriteMovie,
+                    addToFavorites = addMovieToFavorites,
+                    removeFromFavorites = removeMovieFromFavorites
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GetBottomSheetContent(
+    bottomSheetType: BottomSheetType?,
+    sheetUiState: ActorsSheetUIState,
+    movieSheetUIState: MovieSheetUIState,
+    navigateToSelectedMovie: (Int) -> Unit
+) {
+    bottomSheetType?.let { type ->
+        when (type) {
+            BottomSheetType.MovieDetailBottomSheet -> {
+                SheetContentMovieDetails(
+                    movie = movieSheetUIState.selectedMovieDetails,
+                    navigateToSelectedMovie = navigateToSelectedMovie
+                )
+            }
+            BottomSheetType.ActorDetailBottomSheet -> {
+                SheetContentActorDetails(
+                    actor = sheetUiState.selectedActorDetails
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MovieDetailsUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
         MovieDetailsContent(
-            modifier = modifier,
-            uiState = uiState,
-            navigateUp = navigateUp,
-            showFab = showFab,
-            openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
-            selectBottomSheetCallback = selectBottomSheetCallback
+            navigateUp = {},
+            selectBottomSheetCallback = {},
+            showFab = remember { mutableStateOf(true) },
+            openMovieDetailsBottomSheet = { Job() },
+            uiState = MovieDetailsUIState(
+                movieData = fakeMovieDetail,
+                similarMovies = fakeMovieList(),
+                recommendedMovies = fakeMovieList(),
+                movieCast = fakeMovieCastList(),
+                isFetchingDetails = false
+            )
         )
     }
 }
 
-@Preview
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
 @Composable
-private fun MovieDetailsUIPreview() {
-    ComposeActorsTheme {
-        MovieDetailsUI(
-            uiState = MovieDetailsUIState(
-                movieData = null,
-                similarMovies = listOf(),
-                recommendedMovies = listOf(),
-                movieCast = listOf(),
-                isFetchingDetails = false
-            ),
+private fun MovieDetailsUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        MovieDetailsContent(
             navigateUp = {},
-            showFab = rememberSaveable { mutableStateOf(true) },
+            selectBottomSheetCallback = {},
+            showFab = remember { mutableStateOf(true) },
             openMovieDetailsBottomSheet = { Job() },
-            selectBottomSheetCallback = { }
+            uiState = MovieDetailsUIState(
+                movieData = fakeMovieDetail,
+                similarMovies = fakeMovieList(),
+                recommendedMovies = fakeMovieList(),
+                movieCast = fakeMovieCastList(),
+                isFetchingDetails = false
+            )
         )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/MovieDetailsUI.kt
@@ -1,9 +1,14 @@
 package com.developersbreach.composeactors.ui.screens.movieDetail
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.fadeIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.developersbreach.composeactors.data.model.BottomSheetType
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
@@ -12,19 +17,34 @@ import kotlinx.coroutines.Job
 
 @Composable
 fun MovieDetailsUI(
+    modifier: Modifier = Modifier,
     uiState: MovieDetailsUIState,
     navigateUp: () -> Unit,
     showFab: MutableState<Boolean>,
     openMovieDetailsBottomSheet: () -> Job,
     selectBottomSheetCallback: (BottomSheetType) -> Unit
 ) {
-    MovieDetailsContent(
-        uiState = uiState,
-        navigateUp = navigateUp,
-        showFab = showFab,
-        openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
-        selectBottomSheetCallback = selectBottomSheetCallback
-    )
+    val state = remember {
+        MutableTransitionState(false).apply {
+            // Start the animation immediately.
+            targetState = true
+        }
+    }
+
+    AnimatedVisibility(
+        visibleState = state,
+        enter = fadeIn()
+    ) {
+        // Main details content
+        MovieDetailsContent(
+            modifier = modifier,
+            uiState = uiState,
+            navigateUp = navigateUp,
+            showFab = showFab,
+            openMovieDetailsBottomSheet = openMovieDetailsBottomSheet,
+            selectBottomSheetCallback = selectBottomSheetCallback
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/composables/GetMovieCast.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/movieDetail/composables/GetMovieCast.kt
@@ -2,7 +2,15 @@ package com.developersbreach.composeactors.ui.screens.movieDetail.composables
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -14,12 +22,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieDetail
 import com.developersbreach.composeactors.data.model.BottomSheetType
 import com.developersbreach.composeactors.data.model.Cast
 import com.developersbreach.composeactors.ui.components.LoadNetworkImage
 import com.developersbreach.composeactors.ui.screens.movieDetail.MovieDetailsUIState
+import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 import kotlinx.coroutines.Job
 
 @Composable
@@ -89,6 +100,42 @@ private fun ItemCast(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 4.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GetMovieCastLightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        GetMovieCast(
+            uiState = MovieDetailsUIState(
+                movieData = fakeMovieDetail,
+                similarMovies = listOf(),
+                recommendedMovies = listOf(),
+                movieCast = listOf(),
+                isFetchingDetails = false
+            ),
+            openMovieDetailsBottomSheet = { Job() },
+            selectBottomSheetCallback = { }
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun GetMovieCastDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        GetMovieCast(
+            uiState = MovieDetailsUIState(
+                movieData = fakeMovieDetail,
+                similarMovies = listOf(),
+                recommendedMovies = listOf(),
+                movieCast = listOf(),
+                isFetchingDetails = false
+            ),
+            openMovieDetailsBottomSheet = { Job() },
+            selectBottomSheetCallback = {}
         )
     }
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/ActorSearchUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/ActorSearchUI.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.developersbreach.composeactors.data.datasource.fake.fakeActorsList
 import com.developersbreach.composeactors.data.model.Actor
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsScreen
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
@@ -23,7 +24,7 @@ import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 @Composable
 fun ActorSearchUI(
     actorsList: List<Actor>,
-    selectedActor: (Int) -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
     closeKeyboard: () -> Unit?
 ) {
     LazyColumn(
@@ -31,18 +32,22 @@ fun ActorSearchUI(
         modifier = Modifier.padding(bottom = 48.dp)
     ) {
         items(actorsList) { actor ->
-            ItemSearchActor(actor, selectedActor, closeKeyboard)
+            ItemSearchActor(
+                actor = actor,
+                onClickActor = navigateToSelectedActor,
+                closeKeyboard = closeKeyboard
+            )
         }
     }
 }
 
 /**
- * @param selectedActor navigate to actor [ActorDetailsScreen] from user selected actor.
+ * @param onClickActor navigate to actor [ActorDetailsScreen] from user selected actor.
  */
 @Composable
 private fun ItemSearchActor(
     actor: Actor,
-    selectedActor: (Int) -> Unit,
+    onClickActor: (Int) -> Unit,
     closeKeyboard: () -> Unit?
 ) {
     Text(
@@ -51,22 +56,34 @@ private fun ItemSearchActor(
         color = MaterialTheme.colors.onBackground,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 12.dp)
-            .wrapContentWidth(Alignment.Start)
             .clickable {
                 closeKeyboard()
-                selectedActor(actor.actorId)
+                onClickActor(actor.actorId)
             }
+            .padding(horizontal = 20.dp, vertical = 12.dp)
+            .wrapContentWidth(Alignment.Start)
     )
 }
 
-@Preview
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
 @Composable
-private fun ActorSearchUIPreview() {
-    ComposeActorsTheme {
+private fun ActorSearchUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
         ActorSearchUI(
-            actorsList = listOf(),
-            selectedActor = {},
+            actorsList = fakeActorsList(),
+            navigateToSelectedActor = {},
+            closeKeyboard = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ActorSearchUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        ActorSearchUI(
+            actorsList = fakeActorsList(),
+            navigateToSelectedActor = {},
             closeKeyboard = {}
         )
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/MovieSearchUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/MovieSearchUI.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.developersbreach.composeactors.data.datasource.fake.fakeMovieList
 import com.developersbreach.composeactors.data.model.Movie
 import com.developersbreach.composeactors.ui.screens.actorDetails.ActorDetailsScreen
 import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
@@ -23,7 +24,7 @@ import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
 @Composable
 fun MovieSearchUI(
     movieList: List<Movie>,
-    selectedMovie: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit,
     closeKeyboard: () -> Unit?
 ) {
     LazyColumn(
@@ -31,18 +32,22 @@ fun MovieSearchUI(
         modifier = Modifier.padding(bottom = 48.dp)
     ) {
         items(movieList) { movie ->
-            ItemSearchMovie(movie, selectedMovie, closeKeyboard)
+            ItemSearchMovie(
+                movie = movie,
+                onClickMovie = navigateToSelectedMovie,
+                closeKeyboard = closeKeyboard
+            )
         }
     }
 }
 
 /**
- * @param selectedMovie navigate to actor [ActorDetailsScreen] from user selected movie.
+ * @param onClickMovie navigate to actor [ActorDetailsScreen] from user selected movie.
  */
 @Composable
 private fun ItemSearchMovie(
     movie: Movie,
-    selectedMovie: (Int) -> Unit,
+    onClickMovie: (Int) -> Unit,
     closeKeyboard: () -> Unit?
 ) {
     Text(
@@ -53,20 +58,32 @@ private fun ItemSearchMovie(
             .fillMaxWidth()
             .clickable {
                 closeKeyboard()
-                selectedMovie(movie.movieId)
+                onClickMovie(movie.movieId)
             }
             .padding(horizontal = 20.dp, vertical = 12.dp)
             .wrapContentWidth(Alignment.Start)
     )
 }
 
-@Preview
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
 @Composable
-private fun MovieSearchUIPreview() {
-    ComposeActorsTheme {
+private fun MovieSearchUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
         MovieSearchUI(
-            movieList = listOf(),
-            selectedMovie = {},
+            movieList = fakeMovieList(),
+            navigateToSelectedMovie = {},
+            closeKeyboard = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MovieSearchUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        MovieSearchUI(
+            movieList = fakeMovieList(),
+            navigateToSelectedMovie = {},
             closeKeyboard = {}
         )
     }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreen.kt
@@ -1,25 +1,13 @@
 package com.developersbreach.composeactors.ui.screens.search
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Surface
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.testTag
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.developersbreach.composeactors.R
-import com.developersbreach.composeactors.ui.components.ShowSearchProgress
 import com.developersbreach.composeactors.ui.screens.home.HomeScreen
 
-
 /**
- * @param selectedIdSearchType navigates to user clicked actor from row.
  * @param viewModel to manage ui state of [SearchScreen]
  * @param navigateUp navigates user to previous screen.
  *
@@ -27,17 +15,18 @@ import com.developersbreach.composeactors.ui.screens.home.HomeScreen
  * Shows searchable category list of actors in row.
  * Shows [SearchAppBar] search box looking ui in [TopAppBar]
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SearchScreen(
-    selectedIdSearchType: (Int) -> Unit,
-    viewModel: SearchViewModel,
-    navigateUp: () -> Unit
+    viewModel: SearchViewModel = hiltViewModel(),
+    navigateUp: () -> Unit,
+    navigateToSelectedActor: (Int) -> Unit,
+    navigateToSelectedMovie: (Int) -> Unit
 ) {
     val uiState = viewModel.uiState
-    val keyboardController = LocalSoftwareKeyboardController.current
-    val closeKeyboard = {
-        keyboardController?.hide()
+
+    val navigateToSearchBySearchType = when (viewModel.searchType) {
+        SearchType.Actors -> navigateToSelectedActor
+        SearchType.Movies -> navigateToSelectedMovie
     }
 
     val searchHint = when (viewModel.searchType) {
@@ -45,48 +34,11 @@ fun SearchScreen(
         SearchType.Movies -> stringResource(R.string.hint_search_query_movies)
     }
 
-    Surface(
-        color = MaterialTheme.colors.background,
-        modifier = Modifier.semantics { testTag = "TestTag:SearchScreen" }
-    ) {
-        Scaffold(
-            topBar = {
-                SearchAppBar(
-                    navigateUp = navigateUp,
-                    onQueryChange = { viewModel.performQuery(it) },
-                    searchHint = searchHint,
-                    closeKeyboard = closeKeyboard
-                )
-            }
-        ) { paddingValues ->
-            Box(
-                modifier = Modifier.padding(paddingValues)
-            ) {
-                when (uiState) {
-                    is SearchUIState.ActorSearch -> {
-                        // Show progress while search is happening
-                        val isLoadingData = !uiState.isSearchingResults && uiState.actorList.isEmpty()
-                        ShowSearchProgress(isLoadingData)
-                        // Main content for this screen
-                        ActorSearchUI(
-                            actorsList = uiState.actorList,
-                            selectedActor = selectedIdSearchType,
-                            closeKeyboard = closeKeyboard
-                        )
-                    }
-                    is SearchUIState.MovieSearch -> {
-                        // Show progress while search is happening
-                        val isLoadingData = !uiState.isSearchingResults && uiState.movieList.isEmpty()
-                        ShowSearchProgress(isLoadingData)
-                        // Main content for this screen
-                        MovieSearchUI(
-                            movieList = uiState.movieList,
-                            selectedMovie = selectedIdSearchType,
-                            closeKeyboard = closeKeyboard
-                        )
-                    }
-                }
-            }
-        }
-    }
+    SearchScreenUI(
+        navigateUp = navigateUp,
+        navigateToSearchBySearchType = navigateToSearchBySearchType,
+        searchHint = searchHint,
+        onSearchQueryChange = { query -> viewModel.performQuery(query) },
+        uiState = uiState
+    )
 }

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import com.developersbreach.composeactors.R
 import com.developersbreach.composeactors.ui.components.ShowSearchProgress
 import com.developersbreach.composeactors.ui.screens.home.HomeScreen
@@ -44,7 +46,8 @@ fun SearchScreen(
     }
 
     Surface(
-        color = MaterialTheme.colors.background
+        color = MaterialTheme.colors.background,
+        modifier = Modifier.semantics { testTag = "TestTag:SearchScreen" }
     ) {
         Scaffold(
             topBar = {

--- a/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreenUI.kt
+++ b/app/src/main/java/com/developersbreach/composeactors/ui/screens/search/SearchScreenUI.kt
@@ -1,0 +1,113 @@
+package com.developersbreach.composeactors.ui.screens.search
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import com.developersbreach.composeactors.R
+import com.developersbreach.composeactors.data.datasource.fake.fakeActorsList
+import com.developersbreach.composeactors.ui.components.ShowSearchProgress
+import com.developersbreach.composeactors.ui.theme.ComposeActorsTheme
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun SearchScreenUI(
+    navigateUp: () -> Unit,
+    navigateToSearchBySearchType: (Int) -> Unit,
+    searchHint: String,
+    onSearchQueryChange: (query: String) -> Unit,
+    uiState: SearchUIState,
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val closeKeyboard = {
+        keyboardController?.hide()
+    }
+
+    Surface(
+        color = MaterialTheme.colors.background,
+        modifier = Modifier.semantics { testTag = "TestTag:SearchScreen" }
+    ) {
+        Scaffold(
+            topBar = {
+                SearchAppBar(
+                    navigateUp = navigateUp,
+                    onQueryChange = onSearchQueryChange,
+                    searchHint = searchHint,
+                    closeKeyboard = closeKeyboard
+                )
+            }
+        ) { paddingValues ->
+            Box(
+                modifier = Modifier.padding(paddingValues)
+            ) {
+                when (uiState) {
+                    is SearchUIState.ActorSearch -> {
+                        // Show progress while search is happening
+                        val isLoadingData = !uiState.isSearchingResults && uiState.actorList.isEmpty()
+                        ShowSearchProgress(isLoadingData)
+                        // Main content for this screen
+                        ActorSearchUI(
+                            actorsList = uiState.actorList,
+                            navigateToSelectedActor = navigateToSearchBySearchType,
+                            closeKeyboard = closeKeyboard
+                        )
+                    }
+                    is SearchUIState.MovieSearch -> {
+                        // Show progress while search is happening
+                        val isLoadingData = !uiState.isSearchingResults && uiState.movieList.isEmpty()
+                        ShowSearchProgress(isLoadingData)
+                        // Main content for this screen
+                        MovieSearchUI(
+                            movieList = uiState.movieList,
+                            navigateToSelectedMovie = navigateToSearchBySearchType,
+                            closeKeyboard = closeKeyboard
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF211a18)
+@Composable
+private fun SearchScreenUIDarkPreview() {
+    ComposeActorsTheme(darkTheme = true) {
+        SearchScreenUI(
+            navigateUp = {},
+            navigateToSearchBySearchType = {},
+            searchHint = stringResource(R.string.hint_search_query_actors),
+            onSearchQueryChange = {},
+            uiState = SearchUIState.ActorSearch(
+                actorList = fakeActorsList(),
+                isSearchingResults = false
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchScreenUILightPreview() {
+    ComposeActorsTheme(darkTheme = false) {
+        SearchScreenUI(
+            navigateUp = {},
+            navigateToSearchBySearchType = {},
+            searchHint = stringResource(R.string.hint_search_query_actors),
+            onSearchQueryChange = {},
+            uiState = SearchUIState.ActorSearch(
+                actorList = fakeActorsList(),
+                isSearchingResults = false
+            )
+        )
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
 
     ext {
-        compose_version = '1.4.2'
+        compose_version = '1.4.3'
         kotlin_version = '1.8.10'
     }
 


### PR DESCRIPTION
## Description

### Task related to roadmap v0.3.0

- [x] Break composables into smaller for previewing all screens.
- [x] Separate composables into Screen and UI to separated ViewModel usage and previewing for all screens.

### Task status
- Completed